### PR TITLE
feat(dashboard): add products table view with search, category filter…

### DIFF
--- a/src/app/features/dashboard/models/Product.ts
+++ b/src/app/features/dashboard/models/Product.ts
@@ -1,6 +1,12 @@
 export interface Product {
-  imgSrc: string;
-  name: string;
-  category: string;
-  rating: string;
+  id_producto: number;
+  sku: string;
+  nombre: string;
+  descripcion?: string;
+  precio_venta: number;
+  stock_actual: number;
+  imagen_url: string;
+  id_categoria?: number;
+  categoria?: string;
+  fecha_registro: string;
 }

--- a/src/app/features/dashboard/models/ProductCard.ts
+++ b/src/app/features/dashboard/models/ProductCard.ts
@@ -1,0 +1,6 @@
+export interface ProductCard {
+  imgSrc: string;
+  name: string;
+  category: string;
+  rating: string;
+}

--- a/src/app/features/dashboard/pages/overview/overview.component.ts
+++ b/src/app/features/dashboard/pages/overview/overview.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NavbarComponent } from "../../components/navbar/navbar.component";
 import { LucideAngularModule, Plus, Star, TrendingUp, Package, ShoppingCart } from 'lucide-angular';
 import { ProductCardComponent } from "../../components/product-card/product-card.component";
-import { Product } from '../../models/Product';
+import { ProductCard } from '../../models/ProductCard';
 
 @Component({
   selector: 'app-overview',
@@ -21,7 +21,7 @@ export class OverviewComponent {
   readonly Package = Package;
   readonly ShoppingCart = ShoppingCart;
 
-  products: Product[] = [
+  products: ProductCard[] = [
     { imgSrc: 'assets/hardware/esp32.webp', name: 'ESP32 DevKit v1', category: 'Microcontroladores', rating: '4.8' },
     { imgSrc: 'assets/hardware/arduino.webp', name: 'Arduino Uno R3', category: 'Microcontroladores', rating: '4.9' },
     { imgSrc: 'assets/hardware/esp32.webp', name: 'Sensor DHT22 Temperatura y Humedad', category: 'Sensores', rating: '4.7' },

--- a/src/app/features/dashboard/pages/products/products.component.html
+++ b/src/app/features/dashboard/pages/products/products.component.html
@@ -1,6 +1,135 @@
 <div class="space-y-6">
   <app-navbar 
-    pageTitle="PRODUCTOS" 
+    pageTitle="Productos" 
     pageSubtitle="Panel de vendedor">
   </app-navbar>
+
+  <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+    <div class="flex items-center gap-3 w-full sm:w-auto">
+      <div class="relative flex-1 sm:w-72">
+        <lucide-angular [img]="Search" [size]="18" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></lucide-angular>
+        <input
+          type="text"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange()"
+          placeholder="Buscar por nombre o SKU..."
+          class="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 text-sm outline-none focus:border-gray-400 bg-white">
+      </div>
+
+      <select
+        [(ngModel)]="selectedCategory"
+        (ngModelChange)="onCategoryChange()"
+        class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm outline-none focus:border-gray-400 bg-white text-gray-700">
+        <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
+      </select>
+    </div>
+
+    <button class="flex items-center gap-2 px-5 py-2.5 bg-black hover:bg-gray-800 text-white rounded-xl text-sm font-medium transition-colors whitespace-nowrap">
+      <lucide-angular [img]="Plus" [size]="18"></lucide-angular>
+      Agregar producto
+    </button>
+  </div>
+
+  <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="w-full">
+        <thead>
+          <tr class="border-b border-gray-100 bg-gray-50">
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Producto</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">SKU</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Categoría</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Precio</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Stock</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Registro</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Acciones</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <tr *ngFor="let product of paginatedProducts" class="hover:bg-gray-50 transition-colors">
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-lg overflow-hidden bg-gray-100 flex-shrink-0">
+                  <img [src]="product.imagen_url" [alt]="product.nombre" class="w-full h-full object-cover">
+                </div>
+                <span class="text-sm font-medium text-gray-900 line-clamp-1">{{ product.nombre }}</span>
+              </div>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-xs font-mono bg-gray-100 text-gray-600 px-2 py-1 rounded-md">{{ product.sku }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm text-gray-600">{{ product.categoria }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm font-semibold text-gray-900">${{ product.precio_venta }} MXN</span>
+            </td>
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-medium text-gray-900">{{ product.stock_actual }}</span>
+                <span class="text-xs px-2 py-0.5 rounded-full font-medium" [ngClass]="getStockClass(product.stock_actual)">
+                  {{ getStockLabel(product.stock_actual) }}
+                </span>
+              </div>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm text-gray-500">{{ product.fecha_registro }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-2">
+                <button class="p-1.5 hover:bg-gray-100 rounded-lg transition-colors" title="Ver">
+                  <lucide-angular [img]="Eye" [size]="16" class="text-gray-500"></lucide-angular>
+                </button>
+                <button class="p-1.5 hover:bg-blue-50 rounded-lg transition-colors" title="Editar">
+                  <lucide-angular [img]="Edit" [size]="16" class="text-blue-500"></lucide-angular>
+                </button>
+                <button class="p-1.5 hover:bg-red-50 rounded-lg transition-colors" title="Eliminar">
+                  <lucide-angular [img]="Trash2" [size]="16" class="text-red-400"></lucide-angular>
+                </button>
+              </div>
+            </td>
+          </tr>
+
+          <tr *ngIf="paginatedProducts.length === 0">
+            <td colspan="7" class="px-5 py-12 text-center">
+              <div class="flex flex-col items-center gap-3">
+                <lucide-angular [img]="Package" [size]="40" class="text-gray-300"></lucide-angular>
+                <p class="text-gray-500 text-sm">No se encontraron productos</p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Footer con paginación -->
+    <div class="px-5 py-3.5 border-t border-gray-100 bg-gray-50 flex items-center justify-between">
+      <p class="text-xs text-gray-500">
+        Mostrando {{ (currentPage - 1) * itemsPerPage + 1 }}–{{ Math.min(currentPage * itemsPerPage, filteredProducts.length) }} de {{ filteredProducts.length }} producto(s)
+      </p>
+
+      <div class="flex items-center gap-1">
+        <button
+          (click)="goToPage(currentPage - 1)"
+          [disabled]="currentPage === 1"
+          class="p-1.5 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+          <lucide-angular [img]="ChevronLeft" [size]="16" class="text-gray-600"></lucide-angular>
+        </button>
+
+        <button
+          *ngFor="let page of pages"
+          (click)="goToPage(page)"
+          class="w-8 h-8 rounded-lg text-xs font-medium transition-colors"
+          [ngClass]="page === currentPage ? 'bg-black text-white' : 'hover:bg-gray-200 text-gray-600'">
+          {{ page }}
+        </button>
+
+        <button
+          (click)="goToPage(currentPage + 1)"
+          [disabled]="currentPage === totalPages"
+          class="p-1.5 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+          <lucide-angular [img]="ChevronRight" [size]="16" class="text-gray-600"></lucide-angular>
+        </button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/features/dashboard/pages/products/products.component.ts
+++ b/src/app/features/dashboard/pages/products/products.component.ts
@@ -1,13 +1,95 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NavbarComponent } from "../../components/navbar/navbar.component";
+import { LucideAngularModule, Plus, Search, Edit, Trash2, Eye, Package, ChevronLeft, ChevronRight } from 'lucide-angular';
+import { Product } from '../../models/Product';
 
 @Component({
   selector: 'app-products',
   standalone: true,
-  imports: [NavbarComponent],
+  imports: [CommonModule, NavbarComponent, LucideAngularModule, FormsModule],
   templateUrl: './products.component.html',
   styleUrl: './products.component.css'
 })
 export class ProductsComponent {
+  readonly Plus = Plus;
+  readonly Search = Search;
+  readonly Edit = Edit;
+  readonly Trash2 = Trash2;
+  readonly Eye = Eye;
+  readonly Package = Package;
+  readonly ChevronLeft = ChevronLeft;
+  readonly ChevronRight = ChevronRight;
+  readonly Math = Math;
 
+  searchQuery = '';
+  selectedCategory = 'Todos';
+  currentPage = 1;
+  itemsPerPage = 10;
+
+  categories = ['Todos', 'Microcontroladores', 'Sensores', 'Componentes', 'Herramientas y Equipos', 'Kits de Desarrollo', 'Robótica'];
+
+  products: Product[] = [
+    { id_producto: 1, sku: 'MCU-001', nombre: 'ESP32 DevKit v1', categoria: 'Microcontroladores', precio_venta: 120, stock_actual: 45, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-15' },
+    { id_producto: 2, sku: 'MCU-002', nombre: 'Arduino Uno R3', categoria: 'Microcontroladores', precio_venta: 180, stock_actual: 32, imagen_url: 'assets/hardware/arduino.webp', fecha_registro: '2024-01-16' },
+    { id_producto: 3, sku: 'SEN-001', nombre: 'Sensor DHT22 Temperatura y Humedad', categoria: 'Sensores', precio_venta: 65, stock_actual: 80, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-17' },
+    { id_producto: 4, sku: 'SEN-002', nombre: 'Sensor Ultrasónico HC-SR04', categoria: 'Sensores', precio_venta: 45, stock_actual: 0, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-18' },
+    { id_producto: 5, sku: 'CMP-001', nombre: 'Kit Resistencias 1/4W 600pz', categoria: 'Componentes', precio_venta: 89, stock_actual: 25, imagen_url: 'assets/hardware/capacitor.webp', fecha_registro: '2024-01-19' },
+    { id_producto: 6, sku: 'CMP-002', nombre: 'Capacitores Electrolíticos Kit 200pz', categoria: 'Componentes', precio_venta: 75, stock_actual: 40, imagen_url: 'assets/hardware/capacitor.webp', fecha_registro: '2024-01-19' },
+    { id_producto: 7, sku: 'HRR-001', nombre: 'Soldador Temperatura Variable 60W', categoria: 'Herramientas y Equipos', precio_venta: 350, stock_actual: 18, imagen_url: 'assets/hardware/cautin.webp', fecha_registro: '2024-01-20' },
+    { id_producto: 8, sku: 'HRR-002', nombre: 'Multímetro Digital DT830B', categoria: 'Herramientas y Equipos', precio_venta: 220, stock_actual: 30, imagen_url: 'assets/hardware/cautin.webp', fecha_registro: '2024-01-20' },
+    { id_producto: 9, sku: 'KIT-001', nombre: 'Kit Iniciador Arduino Completo', categoria: 'Kits de Desarrollo', precio_venta: 450, stock_actual: 5, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-21' },
+    { id_producto: 10, sku: 'KIT-002', nombre: 'Kit IoT ESP32 con Sensores', categoria: 'Kits de Desarrollo', precio_venta: 380, stock_actual: 22, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-21' },
+    { id_producto: 11, sku: 'ROB-001', nombre: 'Brazo Robótico 4DOF Kit', categoria: 'Robótica', precio_venta: 1200, stock_actual: 8, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-22' },
+    { id_producto: 12, sku: 'ROB-002', nombre: 'Servo Motor SG90 Pack 5pz', categoria: 'Robótica', precio_venta: 95, stock_actual: 0, imagen_url: 'assets/hardware/esp32.webp', fecha_registro: '2024-01-22' },
+  ];
+
+  get filteredProducts(): Product[] {
+    return this.products.filter(p => {
+      const matchesSearch = p.nombre.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
+                           p.sku.toLowerCase().includes(this.searchQuery.toLowerCase());
+      const matchesCategory = this.selectedCategory === 'Todos' || p.categoria === this.selectedCategory;
+      return matchesSearch && matchesCategory;
+    });
+  }
+
+  get paginatedProducts(): Product[] {
+    const start = (this.currentPage - 1) * this.itemsPerPage;
+    return this.filteredProducts.slice(start, start + this.itemsPerPage);
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.filteredProducts.length / this.itemsPerPage);
+  }
+
+  get pages(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
+  }
+
+  goToPage(page: number) {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+    }
+  }
+
+  onSearchChange() {
+    this.currentPage = 1;
+  }
+
+  onCategoryChange() {
+    this.currentPage = 1;
+  }
+
+  getStockClass(stock: number): string {
+    if (stock === 0) return 'bg-red-100 text-red-600';
+    if (stock <= 10) return 'bg-yellow-100 text-yellow-600';
+    return 'bg-green-100 text-green-600';
+  }
+
+  getStockLabel(stock: number): string {
+    if (stock === 0) return 'Sin stock';
+    if (stock <= 10) return 'Stock bajo';
+    return 'En stock';
+  }
 }


### PR DESCRIPTION
## 📋 Descripción
Se implementó la vista de gestión de productos con tabla completa, búsqueda por nombre/SKU, filtro por categoría y paginación. También se separaron los modelos Product y ProductCard para diferenciar el contexto de DB del contexto de UI.

## 🎯 Tipo de cambio
- [x] ✨ Feature (nueva funcionalidad)
- [x] ♻️ Refactor (mejora de código sin cambiar funcionalidad)

## 🧪 ¿Cómo se ha probado?
- Búsqueda por nombre y SKU con reset automático de página
- Filtro por cada categoría disponible
- Paginación con navegación anterior/siguiente y por número de página
- Verificación del estado vacío cuando no hay resultados
- Verificación de badges de stock (sin stock, stock bajo, en stock)
- Build sin errores

## ✅ Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan nuevas advertencias
- [x] El build se genera correctamente (`npm run build`)
- [x] No hay `console.log()`, `debugger` o `TODO` sin resolver

## 📸 Screenshots (si aplica)
**Antes:** Sin vista de productos

**Después:**
- Tabla con imagen, SKU, categoría, precio, stock y acciones por producto
- Buscador y selector de categoría con reset de paginación automático
- Paginación con 8 productos por página y contador de resultados
- Modelos separados: Product (DB) y ProductCard (UI cards del overview)

## 🔗 Issues relacionados
Closes #

## 📝 Notas adicionales
- Los datos son estáticos por ahora, pendiente integración con backend
- Se creó ProductCard.ts como modelo exclusivo para las cards del overview
- Product.ts refleja el schema de la tabla `productos` de la DB