### PR TITLE
feat(dashboard): add orders table view with search, status filter and…

### DIFF
--- a/src/app/features/dashboard/models/Order.ts
+++ b/src/app/features/dashboard/models/Order.ts
@@ -1,0 +1,11 @@
+export interface Order {
+  id_orden: number;
+  id_usuario: number;
+  usuario: string;
+  fecha_orden: string;
+  estado_orden: 'pendiente' | 'confirmada' | 'en_proceso' | 'completada' | 'cancelada';
+  monto_total: number;
+  direccion: string;
+  metodo_pago_tipo: 'tarjeta' | 'efectivo';
+  metodo_pago_ultimos4?: string;
+}

--- a/src/app/features/dashboard/pages/orders/orders.component.html
+++ b/src/app/features/dashboard/pages/orders/orders.component.html
@@ -3,4 +3,118 @@
     pageTitle="PEDIDOS" 
     pageSubtitle="Panel de vendedor">
   </app-navbar>
+
+  <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+    <div class="flex items-center gap-3 w-full sm:w-auto">
+      <div class="relative flex-1 sm:w-72">
+        <lucide-angular [img]="Search" [size]="18" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></lucide-angular>
+        <input
+          type="text"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange()"
+          placeholder="Buscar por cliente o # orden..."
+          class="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 text-sm outline-none focus:border-gray-400 bg-white">
+      </div>
+
+      <select
+        [(ngModel)]="selectedStatus"
+        (ngModelChange)="onStatusChange()"
+        class="px-4 py-2.5 rounded-xl border border-gray-200 text-sm outline-none focus:border-gray-400 bg-white text-gray-700">
+        <option *ngFor="let status of statuses" [value]="status">{{ getStatusLabel(status) }}</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="w-full">
+        <thead>
+          <tr class="border-b border-gray-100 bg-gray-50">
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide"># Orden</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Cliente</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Fecha</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Estado</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Total</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Pago</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Dirección</th>
+            <th class="text-left px-5 py-3.5 text-xs font-semibold text-gray-500 uppercase tracking-wide">Acciones</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <tr *ngFor="let order of paginatedOrders" class="hover:bg-gray-50 transition-colors">
+            <td class="px-5 py-4">
+              <span class="text-xs font-mono bg-gray-100 text-gray-600 px-2 py-1 rounded-md">#{{ order.id_orden }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm font-medium text-gray-900">{{ order.usuario }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm text-gray-500">{{ order.fecha_orden }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-xs px-2.5 py-1 rounded-full font-medium" [ngClass]="getStatusClass(order.estado_orden)">
+                {{ getStatusLabel(order.estado_orden) }}
+              </span>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm font-semibold text-gray-900">${{ order.monto_total }} MXN</span>
+            </td>
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-1.5">
+                <span class="text-sm text-gray-600 capitalize">{{ order.metodo_pago_tipo }}</span>
+                <span *ngIf="order.metodo_pago_ultimos4" class="text-xs text-gray-400">···· {{ order.metodo_pago_ultimos4 }}</span>
+              </div>
+            </td>
+            <td class="px-5 py-4">
+              <span class="text-sm text-gray-500 line-clamp-1 max-w-[160px]">{{ order.direccion }}</span>
+            </td>
+            <td class="px-5 py-4">
+              <button class="p-1.5 hover:bg-gray-100 rounded-lg transition-colors" title="Ver detalle">
+                <lucide-angular [img]="Eye" [size]="16" class="text-gray-500"></lucide-angular>
+              </button>
+            </td>
+          </tr>
+
+          <tr *ngIf="paginatedOrders.length === 0">
+            <td colspan="8" class="px-5 py-12 text-center">
+              <div class="flex flex-col items-center gap-3">
+                <lucide-angular [img]="ShoppingBag" [size]="40" class="text-gray-300"></lucide-angular>
+                <p class="text-gray-500 text-sm">No se encontraron pedidos</p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="px-5 py-3.5 border-t border-gray-100 bg-gray-50 flex items-center justify-between">
+      <p class="text-xs text-gray-500">
+        Mostrando {{ (currentPage - 1) * itemsPerPage + 1 }}–{{ Math.min(currentPage * itemsPerPage, filteredOrders.length) }} de {{ filteredOrders.length }} pedido(s)
+      </p>
+
+      <div class="flex items-center gap-1">
+        <button
+          (click)="goToPage(currentPage - 1)"
+          [disabled]="currentPage === 1"
+          class="p-1.5 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+          <lucide-angular [img]="ChevronLeft" [size]="16" class="text-gray-600"></lucide-angular>
+        </button>
+
+        <button
+          *ngFor="let page of pages"
+          (click)="goToPage(page)"
+          class="w-8 h-8 rounded-lg text-xs font-medium transition-colors"
+          [ngClass]="page === currentPage ? 'bg-black text-white' : 'hover:bg-gray-200 text-gray-600'">
+          {{ page }}
+        </button>
+
+        <button
+          (click)="goToPage(currentPage + 1)"
+          [disabled]="currentPage === totalPages"
+          class="p-1.5 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+          <lucide-angular [img]="ChevronRight" [size]="16" class="text-gray-600"></lucide-angular>
+        </button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/features/dashboard/pages/orders/orders.component.ts
+++ b/src/app/features/dashboard/pages/orders/orders.component.ts
@@ -1,13 +1,95 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NavbarComponent } from "../../components/navbar/navbar.component";
+import { LucideAngularModule, Search, Eye, ChevronLeft, ChevronRight, ShoppingBag } from 'lucide-angular';
+import { Order } from '../../models/Order';
 
 @Component({
   selector: 'app-orders',
   standalone: true,
-  imports: [NavbarComponent],
+  imports: [CommonModule, NavbarComponent, LucideAngularModule, FormsModule],
   templateUrl: './orders.component.html',
   styleUrl: './orders.component.css'
 })
 export class OrdersComponent {
+  readonly Search = Search;
+  readonly Eye = Eye;
+  readonly ChevronLeft = ChevronLeft;
+  readonly ChevronRight = ChevronRight;
+  readonly ShoppingBag = ShoppingBag;
+  readonly Math = Math;
 
+  searchQuery = '';
+  selectedStatus = 'Todos';
+  currentPage = 1;
+  itemsPerPage = 10;
+
+  statuses = ['Todos', 'pendiente', 'confirmada', 'en_proceso', 'completada', 'cancelada'];
+
+  orders: Order[] = [
+    { id_orden: 1001, id_usuario: 1, usuario: 'Carlos Méndez', fecha_orden: '2024-01-15', estado_orden: 'completada', monto_total: 540, direccion: 'Av. Reforma 123, CDMX', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '4242' },
+    { id_orden: 1002, id_usuario: 2, usuario: 'Ana López', fecha_orden: '2024-01-16', estado_orden: 'en_proceso', monto_total: 1200, direccion: 'Calle 5 de Mayo 45, Puebla', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '1234' },
+    { id_orden: 1003, id_usuario: 3, usuario: 'Luis Torres', fecha_orden: '2024-01-17', estado_orden: 'pendiente', monto_total: 89, direccion: 'Blvd. Kukulcán 78, Cancún', metodo_pago_tipo: 'efectivo' },
+    { id_orden: 1004, id_usuario: 4, usuario: 'María García', fecha_orden: '2024-01-18', estado_orden: 'confirmada', monto_total: 630, direccion: 'Av. Juárez 210, Guadalajara', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '5678' },
+    { id_orden: 1005, id_usuario: 5, usuario: 'Pedro Ramírez', fecha_orden: '2024-01-19', estado_orden: 'cancelada', monto_total: 350, direccion: 'Calle Morelos 33, Monterrey', metodo_pago_tipo: 'efectivo' },
+    { id_orden: 1006, id_usuario: 6, usuario: 'Sofía Hernández', fecha_orden: '2024-01-20', estado_orden: 'completada', monto_total: 1800, direccion: 'Av. Universidad 890, CDMX', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '9999' },
+    { id_orden: 1007, id_usuario: 7, usuario: 'Diego Flores', fecha_orden: '2024-01-21', estado_orden: 'pendiente', monto_total: 245, direccion: 'Paseo Montejo 12, Mérida', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '3333' },
+    { id_orden: 1008, id_usuario: 8, usuario: 'Valentina Cruz', fecha_orden: '2024-01-22', estado_orden: 'en_proceso', monto_total: 920, direccion: 'Calle Hidalgo 56, Oaxaca', metodo_pago_tipo: 'efectivo' },
+    { id_orden: 1009, id_usuario: 9, usuario: 'Roberto Díaz', fecha_orden: '2024-01-23', estado_orden: 'confirmada', monto_total: 450, direccion: 'Av. Constitución 77, León', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '7777' },
+    { id_orden: 1010, id_usuario: 10, usuario: 'Isabella Moreno', fecha_orden: '2024-01-24', estado_orden: 'completada', monto_total: 2400, direccion: 'Blvd. López Mateos 321, Tijuana', metodo_pago_tipo: 'tarjeta', metodo_pago_ultimos4: '2222' },
+  ];
+
+  get filteredOrders(): Order[] {
+    return this.orders.filter(o => {
+      const matchesSearch = o.usuario.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
+                           o.id_orden.toString().includes(this.searchQuery);
+      const matchesStatus = this.selectedStatus === 'Todos' || o.estado_orden === this.selectedStatus;
+      return matchesSearch && matchesStatus;
+    });
+  }
+
+  get paginatedOrders(): Order[] {
+    const start = (this.currentPage - 1) * this.itemsPerPage;
+    return this.filteredOrders.slice(start, start + this.itemsPerPage);
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.filteredOrders.length / this.itemsPerPage);
+  }
+
+  get pages(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
+  }
+
+  goToPage(page: number) {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+    }
+  }
+
+  onSearchChange() { this.currentPage = 1; }
+  onStatusChange() { this.currentPage = 1; }
+
+  getStatusClass(status: string): string {
+    const classes: Record<string, string> = {
+      pendiente: 'bg-yellow-100 text-yellow-700',
+      confirmada: 'bg-blue-100 text-blue-700',
+      en_proceso: 'bg-purple-100 text-purple-700',
+      completada: 'bg-green-100 text-green-700',
+      cancelada: 'bg-red-100 text-red-700'
+    };
+    return classes[status] ?? 'bg-gray-100 text-gray-600';
+  }
+
+  getStatusLabel(status: string): string {
+    const labels: Record<string, string> = {
+      pendiente: 'Pendiente',
+      confirmada: 'Confirmada',
+      en_proceso: 'En proceso',
+      completada: 'Completada',
+      cancelada: 'Cancelada'
+    };
+    return labels[status] ?? status;
+  }
 }

--- a/src/app/features/dashboard/pages/products/products.component.html
+++ b/src/app/features/dashboard/pages/products/products.component.html
@@ -1,6 +1,6 @@
 <div class="space-y-6">
   <app-navbar 
-    pageTitle="Productos" 
+    pageTitle="PRODUCTOS" 
     pageSubtitle="Panel de vendedor">
   </app-navbar>
 


### PR DESCRIPTION
## 📋 Descripción
Se implementó la vista de gestión de pedidos con tabla completa, búsqueda por cliente o número de orden, filtro por estado y paginación. Los estados reflejan exactamente el ENUM definido en la base de datos.

## 🎯 Tipo de cambio
- [x] ✨ Feature (nueva funcionalidad)

## 🧪 ¿Cómo se ha probado?
- Búsqueda por nombre de cliente y número de orden con reset de página
- Filtro por cada estado del ENUM (pendiente, confirmada, en_proceso, completada, cancelada)
- Paginación con navegación anterior/siguiente y por número de página
- Verificación del estado vacío cuando no hay resultados
- Verificación de badges de estado con colores diferenciados
- Build sin errores

## ✅ Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan nuevas advertencias
- [x] El build se genera correctamente (`npm run build`)
- [x] No hay `console.log()`, `debugger` o `TODO` sin resolver

## 📸 Screenshots (si aplica)
**Antes:** Sin vista de pedidos

**Después:**
- Tabla con # orden, cliente, fecha, estado, total, método de pago, dirección y acciones
- Badges de estado con colores: amarillo (pendiente), azul (confirmada), morado (en proceso), verde (completada), rojo (cancelada)
- Método de pago con últimos 4 dígitos cuando aplica
- Buscador y filtro de estado con reset de paginación automático

## 🔗 Issues relacionados
Closes #

## 📝 Notas adicionales
- Los datos son estáticos por ahora, pendiente integración con backend
- Los estados del ENUM coinciden exactamente con el schema de la tabla `ordenes`
- La interfaz Order refleja los campos relevantes de la tabla `ordenes` de la DB