### PR TITLE
feat(dashboard): add subscription view with plan details, available p…

### DIFF
--- a/src/app/features/dashboard/components/navbar/navbar.component.html
+++ b/src/app/features/dashboard/components/navbar/navbar.component.html
@@ -43,7 +43,7 @@
         </button>
 
         <button
-          (click)="sendToSettings($event)"
+          (click)="sendToSubscription($event)"
           class="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors w-full text-left">
           <lucide-icon [img]="CreditCard" [size]="18" class="text-gray-500"></lucide-icon>
           <span class="text-sm text-gray-700">Mi suscripción</span>

--- a/src/app/features/dashboard/components/navbar/navbar.component.ts
+++ b/src/app/features/dashboard/components/navbar/navbar.component.ts
@@ -58,4 +58,10 @@ export class NavbarComponent {
     this.isDropdownOpen = false;
     this.router.navigate(['dashboard/settings']);
   }
+
+  sendToSubscription(event: Event) {
+    event.stopPropagation();
+    this.isDropdownOpen = false;
+    this.router.navigate(['dashboard/subscription']);
+  }
 }

--- a/src/app/features/dashboard/dashboard.routes.ts
+++ b/src/app/features/dashboard/dashboard.routes.ts
@@ -40,6 +40,11 @@ export const DASHBOARD_ROUTES: Routes = [
         path: 'settings',
         title: 'Configuración',
         loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent)
+      },
+      {
+        path: 'subscription',
+        title: 'Mi Suscripción',
+        loadComponent: () => import('./pages/subscription/subscription.component').then(m => m.SubscriptionComponent)
       }
     ]
   }

--- a/src/app/features/dashboard/models/Plan.ts
+++ b/src/app/features/dashboard/models/Plan.ts
@@ -1,0 +1,11 @@
+export interface Plan {
+  id: string;
+  name: string;
+  price: number;
+  period: string;
+  description: string;
+  features: string[];
+  limit: string;
+  color: string;
+  icon: any;
+}

--- a/src/app/features/dashboard/pages/subscription/subscription.component.html
+++ b/src/app/features/dashboard/pages/subscription/subscription.component.html
@@ -1,0 +1,150 @@
+<div class="space-y-6">
+  <app-navbar 
+    pageTitle="SUSCRIPCIÓN" 
+    pageSubtitle="Panel de vendedor">
+  </app-navbar>
+
+  <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+    <div class="flex items-start justify-between mb-6">
+      <div>
+        <h3 class="text-lg font-semibold text-gray-900 mb-1">Plan actual</h3>
+        <p class="text-sm text-gray-500">Detalles de tu suscripción activa</p>
+      </div>
+      <span class="px-3 py-1 bg-green-100 text-green-700 text-xs font-semibold rounded-full">
+        {{ subscription.status }}
+      </span>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
+      <div>
+        <p class="text-xs text-gray-400 mb-1">Plan</p>
+        <p class="text-sm font-semibold text-gray-900">{{ subscription.plan }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-gray-400 mb-1">Próximo cobro</p>
+        <div class="flex items-center gap-1.5">
+          <lucide-angular [img]="Calendar" [size]="14" class="text-gray-400"></lucide-angular>
+          <p class="text-sm font-semibold text-gray-900">{{ subscription.nextBilling }}</p>
+        </div>
+      </div>
+      <div>
+        <p class="text-xs text-gray-400 mb-1">Monto</p>
+        <p class="text-sm font-semibold text-gray-900">{{ subscription.amount }} MXN/mes</p>
+      </div>
+      <div>
+        <p class="text-xs text-gray-400 mb-1">Método de pago</p>
+        <div class="flex items-center gap-1.5">
+          <lucide-angular [img]="CreditCard" [size]="14" class="text-gray-400"></lucide-angular>
+          <p class="text-sm font-semibold text-gray-900">{{ subscription.paymentMethod }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-6 pt-6 border-t border-gray-100 flex items-center gap-3">
+      <div class="flex items-center gap-2 text-xs text-yellow-600 bg-yellow-50 px-3 py-2 rounded-lg">
+        <lucide-angular [img]="AlertCircle" [size]="14"></lucide-angular>
+        <span>Comisión del 1.6% aplicada a cada venta realizada</span>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h3 class="text-base font-semibold text-gray-900 mb-4">Planes disponibles</h3>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      @for (plan of plans; track plan.id) {
+        <div class="relative bg-white rounded-xl border-2 transition-all duration-200 p-6"
+          [ngClass]="plan.id === currentPlan 
+            ? 'border-black shadow-md' 
+            : 'border-gray-200 hover:border-gray-300'">
+
+          @if (plan.id === currentPlan) {
+            <div class="absolute -top-3 left-4">
+              <span class="bg-black text-white text-xs font-semibold px-3 py-1 rounded-full">
+                Plan actual
+              </span>
+            </div>
+          }
+
+          <div class="flex items-center gap-3 mb-4">
+            <div class="w-9 h-9 rounded-lg flex items-center justify-center"
+              [ngClass]="getColorClasses(plan.color, 'bg')">
+              <lucide-angular [img]="plan.icon" [size]="18"
+                [ngClass]="getColorClasses(plan.color, 'text')">
+              </lucide-angular>
+            </div>
+            <div>
+              <p class="text-sm font-bold text-gray-900">{{ plan.name }}</p>
+              <p class="text-xs" [ngClass]="getColorClasses(plan.color, 'text')">{{ plan.limit }}</p>
+            </div>
+          </div>
+
+          <div class="flex items-end gap-1 mb-4">
+            <span class="text-3xl font-bold text-gray-900">${{ plan.price }}</span>
+            <span class="text-xs text-gray-400 mb-1">MXN / {{ plan.period }}</span>
+          </div>
+
+          <ul class="flex flex-col gap-2 mb-5">
+            @for (feature of plan.features; track feature) {
+              <li class="flex items-start gap-2 text-xs text-gray-600">
+                <lucide-angular [img]="Check" [size]="14" class="text-green-500 shrink-0 mt-0.5"></lucide-angular>
+                {{ feature }}
+              </li>
+            }
+          </ul>
+
+          <button
+            (click)="changePlan(plan.id)"
+            [disabled]="plan.id === currentPlan"
+            class="w-full py-2.5 rounded-xl text-sm font-semibold transition-colors disabled:cursor-not-allowed"
+            [ngClass]="plan.id === currentPlan
+              ? 'bg-gray-100 text-gray-400'
+              : 'bg-black hover:bg-gray-800 text-white'">
+            {{ plan.id === currentPlan ? 'Plan actual' : plan.id === 'basico' ? 'Cambiar a Básico' : plan.id === 'pro' ? 'Mejorar a Pro' : 'Cambiar plan' }}
+          </button>
+        </div>
+      }
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+    <div class="px-6 py-4 border-b border-gray-100">
+      <h3 class="text-base font-semibold text-gray-900">Historial de pagos</h3>
+    </div>
+    <table class="w-full">
+      <thead>
+        <tr class="bg-gray-50 border-b border-gray-100">
+          <th class="text-left px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Fecha</th>
+          <th class="text-left px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Plan</th>
+          <th class="text-left px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Monto</th>
+          <th class="text-left px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Estado</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100">
+        <tr class="hover:bg-gray-50 transition-colors">
+          <td class="px-6 py-4 text-sm text-gray-600">22 Mar, 2026</td>
+          <td class="px-6 py-4 text-sm font-medium text-gray-900">Vendedor</td>
+          <td class="px-6 py-4 text-sm font-semibold text-gray-900">$199 MXN</td>
+          <td class="px-6 py-4">
+            <span class="px-2.5 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-full">Pagado</span>
+          </td>
+        </tr>
+        <tr class="hover:bg-gray-50 transition-colors">
+          <td class="px-6 py-4 text-sm text-gray-600">22 Feb, 2026</td>
+          <td class="px-6 py-4 text-sm font-medium text-gray-900">Vendedor</td>
+          <td class="px-6 py-4 text-sm font-semibold text-gray-900">$199 MXN</td>
+          <td class="px-6 py-4">
+            <span class="px-2.5 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-full">Pagado</span>
+          </td>
+        </tr>
+        <tr class="hover:bg-gray-50 transition-colors">
+          <td class="px-6 py-4 text-sm text-gray-600">22 Ene, 2026</td>
+          <td class="px-6 py-4 text-sm font-medium text-gray-900">Básico</td>
+          <td class="px-6 py-4 text-sm font-semibold text-gray-900">$99 MXN</td>
+          <td class="px-6 py-4">
+            <span class="px-2.5 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-full">Pagado</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/features/dashboard/pages/subscription/subscription.component.ts
+++ b/src/app/features/dashboard/pages/subscription/subscription.component.ts
@@ -1,0 +1,103 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NavbarComponent } from "../../components/navbar/navbar.component";
+import { LucideAngularModule, Check, Zap, Crown, Rocket, CreditCard, Calendar, AlertCircle } from 'lucide-angular';
+import { Router } from '@angular/router';
+import { Plan } from '../../models/Plan';
+
+@Component({
+  selector: 'app-subscription',
+  standalone: true,
+  imports: [CommonModule, NavbarComponent, LucideAngularModule],
+  templateUrl: './subscription.component.html',
+  styleUrl: './subscription.component.css'
+})
+export class SubscriptionComponent {
+  readonly Check = Check;
+  readonly Zap = Zap;
+  readonly Crown = Crown;
+  readonly Rocket = Rocket;
+  readonly CreditCard = CreditCard;
+  readonly Calendar = Calendar;
+  readonly AlertCircle = AlertCircle;
+
+  currentPlan = 'vendedor';
+
+  subscription = {
+    plan: 'Vendedor',
+    status: 'Activa',
+    nextBilling: '22 de Abril, 2026',
+    amount: '$199',
+    paymentMethod: 'PayPal',
+    startDate: '22 de Marzo, 2026',
+  };
+
+  plans: Plan[] = [
+    {
+      id: 'basico',
+      name: 'Básico',
+      price: 99,
+      period: 'por mes',
+      description: 'Para vendedores que están comenzando.',
+      limit: 'Hasta 50 productos',
+      color: 'blue',
+      icon: Zap,
+      features: [
+        'Hasta 50 productos publicados',
+        'Panel de vendedor',
+        'Estadísticas básicas',
+        'Soporte por correo',
+      ]
+    },
+    {
+      id: 'vendedor',
+      name: 'Vendedor',
+      price: 199,
+      period: 'por mes',
+      description: 'Para tiendas en crecimiento.',
+      limit: 'Hasta 100 productos',
+      color: 'purple',
+      icon: Crown,
+      features: [
+        'Todo lo del plan Básico',
+        'Hasta 100 productos publicados',
+        'Estadísticas avanzadas',
+        'Posicionamiento destacado',
+        'Soporte prioritario',
+      ]
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      price: 499,
+      period: 'por mes',
+      description: 'Para tiendas grandes.',
+      limit: 'Productos ilimitados',
+      color: 'orange',
+      icon: Rocket,
+      features: [
+        'Todo lo del plan Vendedor',
+        'Productos ilimitados',
+        'Analytics avanzado',
+        'Posicionamiento prioritario',
+        'Soporte prioritario 24/7',
+      ]
+    }
+  ];
+
+  constructor(private router: Router) {}
+
+  changePlan(planId: string) {
+    if (planId === this.currentPlan) return;
+    this.router.navigate(['/'], { fragment: 'precios' });
+  }
+
+  getColorClasses(color: string, type: 'bg' | 'text' | 'border' | 'badge') {
+    const map: Record<string, Record<string, string>> = {
+      blue: { bg: 'bg-blue-50', text: 'text-blue-600', border: 'border-blue-200', badge: 'bg-blue-100 text-blue-700' },
+      purple: { bg: 'bg-purple-50', text: 'text-purple-600', border: 'border-purple-200', badge: 'bg-purple-100 text-purple-700' },
+      orange: { bg: 'bg-orange-50', text: 'text-orange-600', border: 'border-orange-200', badge: 'bg-orange-100 text-orange-700' },
+    };
+    return map[color]?.[type] ?? '';
+  }
+}


### PR DESCRIPTION
## 📋 Descripción
Se implementó la vista de suscripción del dashboard con información del plan activo, planes disponibles para cambiar y historial de pagos. Se agregó la ruta `/dashboard/subscription` y la navegación desde el dropdown del navbar.

## 🎯 Tipo de cambio
- [x] ✨ Feature (nueva funcionalidad)

## 🧪 ¿Cómo se ha probado?
- Verificación de la vista mostrando el plan actual con sus detalles
- Verificación de los 3 planes disponibles con el plan actual resaltado
- Verificación del botón deshabilitado en el plan actual
- Verificación del botón "Cambiar plan" redirigiendo a la sección de precios
- Verificación del historial de pagos con fechas y estados
- Verificación de la nota de comisión del 1.6%
- Navegación desde dropdown del navbar funcionando correctamente
- Build sin errores

## ✅ Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan nuevas advertencias
- [x] El build se genera correctamente (`npm run build`)
- [x] No hay `console.log()`, `debugger` o `TODO` sin resolver

## 📸 Screenshots (si aplica)
**Antes:** Sin vista de suscripción, botón "Mi suscripción" redirigía a settings

**Después:**
- Tarjeta con plan activo, próximo cobro, monto y método de pago
- Grid de 3 planes con el actual resaltado en negro
- Botón de cambio de plan redirige a sección de precios de la landing
- Tabla de historial de pagos con fecha, plan, monto y estado
- Nota de comisión del 1.6% visible en la tarjeta del plan actual

## 🔗 Issues relacionados
Closes #

## 📝 Notas adicionales
- Los datos son estáticos por ahora, pendiente integración con backend
- Al cambiar de plan redirige a `/` con fragment `precios` para usar el flujo de PayPal ya implementado
- Se creó `sendToSubscription` en el navbar para la navegación correcta