### PR TITLE
feat: chat con reply, badges en tiempo real, preview inline y emoji p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/leaflet": "^1.9.21",
         "chart.js": "^4.5.1",
         "clsx": "^2.1.1",
+        "emoji-picker-element": "^1.29.1",
         "gsap": "^3.14.2",
         "leaflet": "^1.9.4",
         "lucide-angular": "^0.563.0",
@@ -7506,6 +7507,12 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-picker-element": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-element/-/emoji-picker-element-1.29.1.tgz",
+      "integrity": "sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/leaflet": "^1.9.21",
     "chart.js": "^4.5.1",
     "clsx": "^2.1.1",
+    "emoji-picker-element": "^1.29.1",
     "gsap": "^3.14.2",
     "leaflet": "^1.9.4",
     "lucide-angular": "^0.563.0",

--- a/src/app/features/dashboard/models/chat.models.ts
+++ b/src/app/features/dashboard/models/chat.models.ts
@@ -18,4 +18,9 @@ export interface Mensaje {
   archivo_url: string | null;
   leido: boolean;
   created_at: string;
+  id_mensaje_reply?: number | null;
+  reply_contenido?: string | null;
+  reply_nombre_remitente?: string | null;
+  reply_tipo_mensaje?: string | null;
+  reply_archivo_url?: string | null;
 }

--- a/src/app/features/dashboard/pages/chat/chat.component.html
+++ b/src/app/features/dashboard/pages/chat/chat.component.html
@@ -2,7 +2,6 @@
   <app-navbar pageTitle="CHAT" pageSubtitle="Panel de vendedor"></app-navbar>
   <div class="flex h-[calc(100vh-160px)] rounded-2xl border border-gray-100 overflow-hidden bg-white shadow-sm w-full">
 
-    <!-- Lista de conversaciones -->
     <div class="w-80 flex-shrink-0 border-r border-gray-100 flex flex-col">
       <div class="p-4 border-b border-gray-100">
         <div class="relative">
@@ -39,7 +38,7 @@
                   {{ conv.nombre_usuario.charAt(0).toUpperCase() }}
                 </div>
                 @if (conv.no_leidos > 0) {
-                  <span class="absolute -top-0.5 -right-0.5 w-4 h-4 bg-black text-white text-[10px] rounded-full flex items-center justify-center">
+                  <span class="absolute -top-0.5 -right-0.5 w-5 h-5 bg-[#CCDAFF] text-[#1e3a8a] text-[10px] font-bold rounded-full flex items-center justify-center">
                     {{ conv.no_leidos }}
                   </span>
                 }
@@ -59,7 +58,6 @@
       </div>
     </div>
 
-    <!-- Panel de mensajes -->
     @if (!conversacionSeleccionada) {
       <div class="flex-1 flex flex-col items-center justify-center text-gray-400 gap-3">
         <svg class="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -70,7 +68,6 @@
     } @else {
       <div class="flex-1 flex flex-col min-w-0">
 
-        <!-- Header -->
         <div class="px-6 py-4 border-b border-gray-100 flex items-center gap-3">
           <div class="w-9 h-9 rounded-full bg-black flex items-center justify-center text-white text-sm font-medium">
             {{ conversacionSeleccionada.nombre_usuario.charAt(0).toUpperCase() }}
@@ -81,7 +78,6 @@
           </div>
         </div>
 
-        <!-- Mensajes -->
         <div #mensajesContainer class="flex-1 overflow-y-auto px-6 py-4 space-y-3">
           @if (isLoadingMensajes) {
             <div class="flex items-center justify-center h-full">
@@ -89,9 +85,19 @@
             </div>
           } @else {
             @for (msg of mensajes; track msg.id_mensaje) {
-              <div class="flex" [class.justify-end]="msg.id_remitente === idUsuario">
-                <div class="max-w-xs lg:max-w-md">
+              <div class="flex group items-end gap-1" [class.justify-end]="msg.id_remitente === idUsuario">
 
+                @if (msg.id_remitente === idUsuario) {
+                  <button (click)="responderMensaje(msg)"
+                    class="mb-5 opacity-0 group-hover:opacity-100 transition-opacity w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center hover:bg-gray-200 flex-shrink-0">
+                    <svg class="w-3.5 h-3.5 text-gray-500 scale-x-[-1]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <polyline points="9 17 4 12 9 7"></polyline>
+                      <path d="M20 18v-2a4 4 0 0 0-4-4H4"></path>
+                    </svg>
+                  </button>
+                }
+
+                <div class="max-w-xs lg:max-w-md">
                   <div
                     class="rounded-2xl text-sm overflow-hidden"
                     [class.bg-black]="msg.id_remitente === idUsuario"
@@ -99,44 +105,65 @@
                     [class.bg-gray-100]="msg.id_remitente !== idUsuario"
                     [class.text-gray-900]="msg.id_remitente !== idUsuario"
                     [class.rounded-br-sm]="msg.id_remitente === idUsuario"
-                    [class.rounded-bl-sm]="msg.id_remitente !== idUsuario"
-                    [class.px-4]="msg.tipo_mensaje === 'texto' || !msg.tipo_mensaje"
-                    [class.py-2]="msg.tipo_mensaje === 'texto' || !msg.tipo_mensaje || msg.tipo_mensaje === 'archivo'"
-                    [class.px-3]="msg.tipo_mensaje === 'archivo'"
-                    [class.p-1]="msg.tipo_mensaje === 'imagen' || msg.tipo_mensaje === 'video'">
+                    [class.rounded-bl-sm]="msg.id_remitente !== idUsuario">
+
+                    @if (msg.id_mensaje_reply) {
+                      <div class="px-3 pt-2.5 pb-2 border-b mx-2 mt-2 rounded-lg"
+                        [ngClass]="msg.id_remitente === idUsuario ? 'bg-white/10 border-white/20' : 'bg-black/5 border-gray-300'">
+                        <div class="flex items-center gap-1.5 mb-0.5">
+                          <div class="w-0.5 h-3 rounded-full flex-shrink-0"
+                            [ngClass]="msg.id_remitente === idUsuario ? 'bg-white' : 'bg-gray-500'"></div>
+                          <p class="text-[10px] font-semibold truncate opacity-80">{{ msg.reply_nombre_remitente }}</p>
+                        </div>
+                        <p class="text-[11px] opacity-70 truncate pl-2">
+                          @if (msg.reply_tipo_mensaje === 'imagen') { 📷 Imagen }
+                          @else if (msg.reply_tipo_mensaje === 'video') { 🎥 Video }
+                          @else if (msg.reply_tipo_mensaje === 'archivo') { 📎 Archivo }
+                          @else { {{ msg.reply_contenido }} }
+                        </p>
+                      </div>
+                    }
 
                     @if (msg.tipo_mensaje === 'imagen') {
                       <img
                         [src]="msg.archivo_url"
                         alt="Imagen del mensaje"
-                        class="rounded-xl max-w-full max-h-60 object-cover cursor-pointer hover:opacity-90 transition-opacity"
+                        class="max-w-full max-h-60 object-cover cursor-pointer hover:opacity-90 transition-opacity"
+                        [class.mt-2]="msg.id_mensaje_reply"
                         (click)="abrirImagen(msg.archivo_url!)"/>
                       @if (msg.contenido) {
-                        <p class="text-xs px-3 pt-2 pb-1 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
+                        <p class="text-xs px-3 pt-2 pb-2 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
+                      } @else {
+                        <div class="pb-1"></div>
                       }
                     } @else if (msg.tipo_mensaje === 'video') {
-                      <video [src]="msg.archivo_url" controls class="rounded-xl max-w-full max-h-60"></video>
+                      <video [src]="msg.archivo_url" controls class="max-w-full max-h-60"
+                        [class.mt-2]="msg.id_mensaje_reply"></video>
                       @if (msg.contenido) {
-                        <p class="text-xs px-3 pt-2 pb-1 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
+                        <p class="text-xs px-3 pt-2 pb-2 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
+                      } @else {
+                        <div class="pb-1"></div>
                       }
                     } @else if (msg.tipo_mensaje === 'archivo') {
-                      <a [href]="msg.archivo_url" target="_blank"
-                         class="flex items-center gap-2 hover:opacity-80 transition-opacity">
-                        <div class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                             [class.bg-gray-700]="msg.id_remitente === idUsuario"
-                             [class.bg-gray-300]="msg.id_remitente !== idUsuario">
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                              d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
-                          </svg>
-                        </div>
-                        <span class="text-xs underline underline-offset-2">Descargar archivo</span>
-                      </a>
-                      @if (msg.contenido) {
-                        <p class="text-xs pt-2 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
-                      }
+                      <div class="px-3 py-2" [class.pt-2]="msg.id_mensaje_reply">
+                        <a [href]="msg.archivo_url" target="_blank"
+                           class="flex items-center gap-2 hover:opacity-80 transition-opacity">
+                          <div class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+                               [class.bg-gray-700]="msg.id_remitente === idUsuario"
+                               [class.bg-gray-300]="msg.id_remitente !== idUsuario">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+                            </svg>
+                          </div>
+                          <span class="text-xs underline underline-offset-2">Descargar archivo</span>
+                        </a>
+                        @if (msg.contenido) {
+                          <p class="text-xs pt-2 opacity-90 leading-relaxed">{{ msg.contenido }}</p>
+                        }
+                      </div>
                     } @else {
-                      <span class="px-1">{{ msg.contenido }}</span>
+                      <span class="block px-4 py-2">{{ msg.contenido }}</span>
                     }
 
                   </div>
@@ -144,14 +171,23 @@
                   <p class="text-[10px] text-gray-400 mt-1" [class.text-right]="msg.id_remitente === idUsuario">
                     {{ msg.created_at | date:'HH:mm' }}
                   </p>
-
                 </div>
+
+                @if (msg.id_remitente !== idUsuario) {
+                  <button (click)="responderMensaje(msg)"
+                    class="mb-5 opacity-0 group-hover:opacity-100 transition-opacity w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center hover:bg-gray-200 flex-shrink-0">
+                    <svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <polyline points="9 17 4 12 9 7"></polyline>
+                      <path d="M20 18v-2a4 4 0 0 0-4-4H4"></path>
+                    </svg>
+                  </button>
+                }
+
               </div>
             }
           }
         </div>
 
-        <!-- Typing indicator -->
         @if (escribiendo) {
           <p class="px-6 pb-2">
             <span class="bg-black text-white px-4 py-2 rounded-full text-xs italic tracking-wide">
@@ -160,111 +196,115 @@
           </p>
         }
 
-        <!-- Input -->
-        <div class="px-6 py-4 border-t border-gray-100">
-          <div class="flex items-center gap-3">
-
-            <label
-              class="w-10 h-10 rounded-xl bg-gray-100 flex items-center justify-center cursor-pointer hover:bg-gray-200 transition-colors flex-shrink-0"
-              [class.opacity-40]="subiendoArchivo"
-              [class.pointer-events-none]="subiendoArchivo">
-              @if (subiendoArchivo) {
-                <span class="w-4 h-4 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></span>
-              } @else {
-                <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+        <div class="border-t border-gray-100">
+          @if (replyingTo) {
+            <div class="flex items-center gap-3 px-6 py-2.5 bg-gray-50 border-b border-gray-100">
+              <div class="w-0.5 h-9 bg-black rounded-full flex-shrink-0"></div>
+              <div class="flex-1 min-w-0">
+                <p class="text-[10px] font-semibold text-gray-800 truncate">{{ replyingTo.nombre_remitente }}</p>
+                <p class="text-xs text-gray-500 truncate">
+                  @if (replyingTo.tipo_mensaje === 'imagen') { 📷 Imagen }
+                  @else if (replyingTo.tipo_mensaje === 'video') { 🎥 Video }
+                  @else if (replyingTo.tipo_mensaje === 'archivo') { 📎 Archivo }
+                  @else { {{ replyingTo.contenido }} }
+                </p>
+              </div>
+              <button (click)="cancelarRespuesta()"
+                class="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center hover:bg-gray-300 flex-shrink-0 transition-colors">
+                <svg class="w-3 h-3 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                 </svg>
-              }
-              <input type="file" class="hidden"
-                accept="image/*,video/*,.pdf,.doc,.docx,.xls,.xlsx"
-                (change)="subirArchivo($event)"/>
-            </label>
+              </button>
+            </div>
+          }
 
-            <input type="text" placeholder="Escribe un mensaje..."
-              [(ngModel)]="nuevoMensaje"
-              (ngModelChange)="onEscribiendo()"
-              (keydown.enter)="enviarMensaje()"
-              class="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors"/>
+          <div class="px-6 py-4 relative">
+            @if (mostrarEmojis) {
+              <div class="fixed inset-0" style="z-index: 9" (click)="mostrarEmojis = false"></div>
+              <div class="absolute bottom-full left-0 mb-2" style="z-index: 10" (click)="$event.stopPropagation()">
+                <emoji-picker (emoji-click)="insertarEmoji($event)"></emoji-picker>
+              </div>
+            }
 
-            <button (click)="enviarMensaje()" [disabled]="!nuevoMensaje.trim()"
-              class="w-10 h-10 rounded-xl bg-black text-white flex items-center justify-center hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0">
-              <svg class="w-4 h-4 rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
-              </svg>
-            </button>
+            @if (archivoPreview) {
+              <div class="flex items-center gap-3 bg-gray-50 rounded-xl border border-gray-200 px-3 py-2.5">
+                <button (click)="cancelarArchivoPreview()"
+                  class="w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center hover:bg-gray-300 flex-shrink-0 transition-colors">
+                  <svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+                </button>
+                @if (archivoPreviewUrl && archivoPreview.type.startsWith('image/')) {
+                  <img [src]="archivoPreviewUrl" class="w-12 h-12 rounded-lg object-cover flex-shrink-0" alt="preview"/>
+                } @else if (archivoPreviewUrl && archivoPreview.type.startsWith('video/')) {
+                  <div class="w-12 h-12 rounded-lg bg-gray-800 flex items-center justify-center flex-shrink-0 text-xl">🎥</div>
+                } @else {
+                  <div class="w-12 h-12 rounded-lg bg-gray-200 flex items-center justify-center flex-shrink-0 text-xl">📎</div>
+                }
+                <div class="flex-1 min-w-0">
+                  <p class="text-[10px] text-gray-400 truncate mb-1">{{ archivoPreview.name }}</p>
+                  <input type="text" placeholder="Añadir comentario..."
+                    [(ngModel)]="captionTexto"
+                    (keydown.enter)="enviarArchivoConCaption()"
+                    (keydown.escape)="cancelarArchivoPreview()"
+                    class="w-full bg-transparent outline-none text-sm text-gray-800 placeholder-gray-400"/>
+                </div>
+                <button (click)="mostrarEmojis = !mostrarEmojis"
+                  class="w-9 h-9 rounded-xl bg-gray-200 flex items-center justify-center hover:bg-gray-300 transition-colors flex-shrink-0 text-lg">
+                  😊
+                </button>
+                <button (click)="enviarArchivoConCaption()" [disabled]="subiendoArchivo"
+                  class="w-10 h-10 rounded-xl bg-black text-white flex items-center justify-center hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0">
+                  @if (subiendoArchivo) {
+                    <span class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+                  } @else {
+                    <svg class="w-4 h-4 rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+                    </svg>
+                  }
+                </button>
+              </div>
+            } @else {
+              <div class="flex items-center gap-3">
+                <label
+                  class="w-10 h-10 rounded-xl bg-gray-100 flex items-center justify-center cursor-pointer hover:bg-gray-200 transition-colors flex-shrink-0"
+                  [class.opacity-40]="subiendoArchivo"
+                  [class.pointer-events-none]="subiendoArchivo">
+                  @if (subiendoArchivo) {
+                    <span class="w-4 h-4 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></span>
+                  } @else {
+                    <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+                    </svg>
+                  }
+                  <input type="file" class="hidden"
+                    accept="image/*,video/*,.pdf,.doc,.docx,.xls,.xlsx"
+                    (change)="subirArchivo($event)"/>
+                </label>
 
+                <button (click)="mostrarEmojis = !mostrarEmojis"
+                  class="w-10 h-10 rounded-xl bg-gray-100 flex items-center justify-center hover:bg-gray-200 transition-colors flex-shrink-0 text-xl">
+                  😊
+                </button>
+
+                <input type="text" placeholder="Escribe un mensaje..."
+                  [(ngModel)]="nuevoMensaje"
+                  (ngModelChange)="onEscribiendo()"
+                  (keydown.enter)="enviarMensaje()"
+                  class="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors"/>
+
+                <button (click)="enviarMensaje()" [disabled]="!nuevoMensaje.trim()"
+                  class="w-10 h-10 rounded-xl bg-black text-white flex items-center justify-center hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0">
+                  <svg class="w-4 h-4 rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+                  </svg>
+                </button>
+              </div>
+            }
           </div>
         </div>
-
       </div>
     }
-
   </div>
 </div>
-
-<!-- Modal preview archivo -->
-@if (mostrarModalArchivo) {
-  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-50" (click.self)="cerrarModalArchivo()">
-    <div class="bg-white rounded-2xl p-5 w-96 flex flex-col gap-4 shadow-2xl">
-
-      <!-- Header modal -->
-      <div class="flex items-center justify-between">
-        <h3 class="text-sm font-semibold text-gray-900">Vista previa</h3>
-        <button (click)="cerrarModalArchivo()"
-          class="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center hover:bg-gray-200 transition-colors">
-          <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-          </svg>
-        </button>
-      </div>
-
-      <!-- Preview -->
-      <div class="rounded-xl overflow-hidden bg-gray-50 flex items-center justify-center min-h-48 max-h-64">
-        @if (archivoPreviewUrl && archivoPreview?.type?.startsWith('image/')) {
-          <img [src]="archivoPreviewUrl" class="max-w-full max-h-64 object-contain" alt="Vista previa del archivo"/>
-        } @else if (archivoPreviewUrl && archivoPreview?.type?.startsWith('video/')) {
-          <video [src]="archivoPreviewUrl" controls class="max-w-full max-h-64"></video>
-        } @else {
-          <div class="flex flex-col items-center gap-3 py-8 px-4 text-center">
-            <div class="w-12 h-12 rounded-xl bg-gray-200 flex items-center justify-center">
-              <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-              </svg>
-            </div>
-            <p class="text-sm text-gray-600 break-all">{{ archivoPreview?.name }}</p>
-          </div>
-        }
-      </div>
-
-      <!-- Caption input -->
-      <input
-        type="text"
-        placeholder="Añadir comentario... (opcional)"
-        [(ngModel)]="captionTexto"
-        (keydown.enter)="enviarArchivoConCaption()"
-        (keydown.escape)="cerrarModalArchivo()"
-        #captionInput
-        class="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors"/>
-
-      <!-- Botones -->
-      <div class="flex gap-2">
-        <button (click)="cerrarModalArchivo()"
-          class="flex-1 py-2.5 rounded-xl bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition-colors">
-          Cancelar
-        </button>
-        <button (click)="enviarArchivoConCaption()" [disabled]="subiendoArchivo"
-          class="flex-1 py-2.5 rounded-xl bg-black text-white text-sm font-medium hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2">
-          @if (subiendoArchivo) {
-            <span class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
-            Enviando...
-          } @else {
-            Enviar
-          }
-        </button>
-      </div>
-
-    </div>
-  </div>
-}

--- a/src/app/features/dashboard/pages/chat/chat.component.ts
+++ b/src/app/features/dashboard/pages/chat/chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
@@ -9,11 +9,13 @@ import { AuthService } from '../../../auth/services/auth.service';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { environment } from '../../../../../environments/environment';
+import 'emoji-picker-element';
 
 @Component({
   selector: 'app-chat',
   standalone: true,
   imports: [CommonModule, FormsModule, NavbarComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './chat.component.html',
   styleUrl: './chat.component.css',
 })
@@ -32,11 +34,13 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
   idEmpresa = 0;
   idUsuario = 0;
 
-  mostrarModalArchivo = false;
   archivoPreview: File | null = null;
   archivoPreviewUrl: string | null = null;
   captionTexto = '';
   subiendoArchivo = false;
+
+  replyingTo: Mensaje | null = null;
+  mostrarEmojis = false;
 
   private shouldScroll = false;
   private destroy$ = new Subject<void>();
@@ -72,7 +76,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
           this.shouldScroll = true;
           this.chatService.marcarLeido(msg.id_conversacion, this.idUsuario);
         }
-        this.cargarConversaciones();
+        const conv = this.conversaciones.find(c => c.id_conversacion === msg.id_conversacion);
+        if (conv) {
+          conv.ultimo_mensaje = msg.tipo_mensaje === 'texto' ? msg.contenido : '📎 Archivo';
+          conv.ultimo_mensaje_fecha = msg.created_at;
+        }
       });
 
     this.chatService.onUsuarioEscribiendo()
@@ -82,6 +90,21 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.chatService.onUsuarioDejoEscribir()
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => { this.escribiendo = ''; });
+
+    this.chatService.onBadgeUpdate()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((data) => {
+        const conv = this.conversaciones.find(c => c.id_conversacion === data.id_conversacion);
+        if (conv) {
+          if (this.conversacionSeleccionada?.id_conversacion !== data.id_conversacion) {
+            conv.no_leidos = (conv.no_leidos || 0) + 1;
+          }
+          if (data.ultimo_mensaje !== undefined) {
+            conv.ultimo_mensaje = data.tipo_mensaje === 'texto' ? data.ultimo_mensaje : '📎 Archivo';
+            conv.ultimo_mensaje_fecha = data.ultimo_mensaje_fecha ?? conv.ultimo_mensaje_fecha;
+          }
+        }
+      });
 
     this.typingSubject$
       .pipe(debounceTime(1000), takeUntil(this.destroy$))
@@ -111,6 +134,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
     ).subscribe({
       next: (empresa) => {
         this.idEmpresa = empresa.id_empresa;
+        this.chatService.unirseAEmpresa(this.idEmpresa);
         this.cargarConversaciones();
       },
       error: () => {
@@ -133,6 +157,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   seleccionarConversacion(conv: Conversacion): void {
     this.conversacionSeleccionada = conv;
+    conv.no_leidos = 0;
     this.isLoadingMensajes = true;
     this.chatService.unirseAConversacion(conv.id_conversacion);
 
@@ -163,19 +188,13 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.chatService.enviarMensaje(
       this.conversacionSeleccionada.id_conversacion,
       this.idUsuario,
-      this.nuevoMensaje.trim()
+      this.nuevoMensaje.trim(),
+      this.replyingTo?.id_mensaje
     );
     this.nuevoMensaje = '';
+    this.replyingTo = null;
+    this.mostrarEmojis = false;
     this.typingSubject$.next();
-  }
-
-  private scrollAlFinal(): void {
-    try {
-      this.mensajesContainer.nativeElement.scrollTop =
-        this.mensajesContainer.nativeElement.scrollHeight;
-    } catch {
-      // scroll ignorado si el contenedor no está disponible
-    }
   }
 
   subirArchivo(event: Event): void {
@@ -193,11 +212,9 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
     } else {
       this.archivoPreviewUrl = null;
     }
-    this.mostrarModalArchivo = true;
   }
 
-  cerrarModalArchivo(): void {
-    this.mostrarModalArchivo = false;
+  cancelarArchivoPreview(): void {
     this.archivoPreview = null;
     this.archivoPreviewUrl = null;
     this.captionTexto = '';
@@ -206,19 +223,20 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
   enviarArchivoConCaption(): void {
     if (!this.archivoPreview || !this.conversacionSeleccionada || this.subiendoArchivo) return;
     this.subiendoArchivo = true;
-    this.mostrarModalArchivo = false;
 
     this.chatService.subirArchivo(
       this.conversacionSeleccionada.id_conversacion,
       this.idUsuario,
       this.archivoPreview,
-      this.captionTexto
+      this.captionTexto,
+      this.replyingTo?.id_mensaje
     ).subscribe({
       next: () => {
         this.subiendoArchivo = false;
         this.archivoPreview = null;
         this.archivoPreviewUrl = null;
         this.captionTexto = '';
+        this.replyingTo = null;
       },
       error: (err) => {
         console.error('Error subiendo archivo:', err);
@@ -227,7 +245,35 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewChecked {
     });
   }
 
+  responderMensaje(msg: Mensaje): void {
+    this.replyingTo = msg;
+    this.mostrarEmojis = false;
+  }
+
+  cancelarRespuesta(): void {
+    this.replyingTo = null;
+  }
+
+  insertarEmoji(event: Event): void {
+    const emoji = (event as CustomEvent).detail?.unicode ?? '';
+    if (this.archivoPreview) {
+      this.captionTexto += emoji;
+    } else {
+      this.nuevoMensaje += emoji;
+    }
+    this.mostrarEmojis = false;
+  }
+
   abrirImagen(url: string): void {
     window.open(url, '_blank');
+  }
+
+  private scrollAlFinal(): void {
+    try {
+      this.mensajesContainer.nativeElement.scrollTop =
+        this.mensajesContainer.nativeElement.scrollHeight;
+    } catch {
+      // ignorado si el contenedor no está disponible
+    }
   }
 }

--- a/src/app/features/dashboard/services/chat.service.ts
+++ b/src/app/features/dashboard/services/chat.service.ts
@@ -11,14 +11,30 @@ export class ChatService {
   private mensajeNuevo$ = new Subject<Mensaje>();
   private usuarioEscribiendo$ = new Subject<string>();
   private usuarioDejoEscribir$ = new Subject<void>();
+  private badgeUpdate$ = new Subject<{ id_conversacion: number; ultimo_mensaje?: string | null; tipo_mensaje?: string; ultimo_mensaje_fecha?: string }>();
+
+  private idEmpresaActual: number | null = null;
+  private idConversacionActual: number | null = null;
 
   constructor(private http: HttpClient) {}
 
   conectar(): void {
     this.socket = io(environment.socketUrl, {
-      auth: {
-        token: localStorage.getItem('access_token')
+      auth: { token: localStorage.getItem('access_token') }
+    });
+
+    // Re-unirse a los rooms al reconectar
+    this.socket.on('connect', () => {
+      if (this.idEmpresaActual) {
+        this.socket.emit('join_empresa', this.idEmpresaActual);
       }
+      if (this.idConversacionActual) {
+        this.socket.emit('join_conversation', this.idConversacionActual);
+      }
+    });
+
+    this.socket.on('badge_update', (data) => {
+      this.badgeUpdate$.next(data);
     });
 
     this.socket.on('new_message', (msg: Mensaje) => {
@@ -39,14 +55,21 @@ export class ChatService {
   }
 
   unirseAConversacion(idConversacion: number): void {
+    this.idConversacionActual = idConversacion;
     this.socket.emit('join_conversation', idConversacion);
   }
 
-  enviarMensaje(idConversacion: number, idRemitente: number, contenido: string): void {
+  unirseAEmpresa(idEmpresa: number): void {
+    this.idEmpresaActual = idEmpresa;
+    this.socket.emit('join_empresa', idEmpresa);
+  }
+
+  enviarMensaje(idConversacion: number, idRemitente: number, contenido: string, idMensajeReply?: number | null): void {
     this.socket.emit('send_message', {
       id_conversacion: idConversacion,
       id_remitente: idRemitente,
-      contenido
+      contenido,
+      id_mensaje_reply: idMensajeReply ?? null
     });
   }
 
@@ -84,23 +107,28 @@ export class ChatService {
     return this.usuarioDejoEscribir$.asObservable();
   }
 
+  onBadgeUpdate(): Observable<{ id_conversacion: number; ultimo_mensaje?: string | null; tipo_mensaje?: string; ultimo_mensaje_fecha?: string }> {
+    return this.badgeUpdate$.asObservable();
+  }
+
   getConversacionesPorEmpresa(idEmpresa: number): Observable<Conversacion[]> {
     return this.http.get<Conversacion[]>(
-      `${environment.apiUrl}/empresas/${idEmpresa}/conversaciones`
+      `${environment.apiUrl}/empresas/${idEmpresa}/conversaciones?t=${Date.now()}`
     );
   }
 
   getMensajes(idConversacion: number): Observable<Mensaje[]> {
     return this.http.get<Mensaje[]>(
-      `${environment.apiUrl}/conversaciones/${idConversacion}/mensajes`
+      `${environment.apiUrl}/conversaciones/${idConversacion}/mensajes?t=${Date.now()}`
     );
   }
 
-  subirArchivo(idConversacion: number, idRemitente: number, file: File, caption?: string): Observable<Mensaje> {
+  subirArchivo(idConversacion: number, idRemitente: number, file: File, caption?: string, idMensajeReply?: number | null): Observable<Mensaje> {
     const formData = new FormData();
     formData.append('archivo', file);
     formData.append('id_remitente', idRemitente.toString());
     if (caption?.trim()) formData.append('caption', caption.trim());
+    if (idMensajeReply) formData.append('id_mensaje_reply', idMensajeReply.toString());
 
     return this.http.post<Mensaje>(
       `${environment.apiUrl}/conversaciones/${idConversacion}/archivo`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
## 📋 Descripción
Implementación completa del sistema de chat estilo WhatsApp en el dashboard de empresa. Incluye respuesta a mensajes (reply/citar), badge de mensajes no leídos en tiempo real, preview inline de archivos en el input, selector de emojis y actualización del último mensaje sin recargar la página.

## 🎯 Tipo de cambio
- [x] ✨ Feature (nueva funcionalidad)
- [x] 🐛 Bugfix (corrección de bug)

## 🧪 ¿Cómo se ha probado?
- Envío y recepción de mensajes de texto en tiempo real via socket
- Reply a mensajes: se muestra la cita dentro de la burbuja
- Subida de imágenes con caption inline (sin modal)
- Badge de no leídos aparece en tiempo real al recibir mensajes de otras conversaciones
- Badge se limpia al abrir la conversación
- Preview del último mensaje se actualiza sin recargar la lista
- Selector de emojis funcional insertando el carácter en el input

## ✅ Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan nuevas advertencias
- [x] El build se genera correctamente (`npm run build`)

## 📸 Screenshots (si aplica)
<!-- Agrega capturas del chat con badge, reply y preview inline -->

**Antes:** Lista de conversaciones sin badges, sin reply, preview de archivos en modal

**Después:** Badges en tiempo real, reply estilo WhatsApp, preview inline en input bar, último mensaje actualizado sin reload

## 🔗 Issues relacionados
Closes #

## 📝 Notas adicionales
- El badge se actualiza localmente (sin llamadas HTTP) para evitar parpadeo en la lista
- Se usa `badge_update` socket event con payload del último mensaje para sincronizar el preview
- Requiere correr la migración `migrations/add_reply_chat.sql` en la base de datos antes de desplegar el backend correspondiente
